### PR TITLE
change: Quarogテーマの配色を変更

### DIFF
--- a/src/KyoshinEewViewer.Core/IntensityThemes/Quarog.axaml
+++ b/src/KyoshinEewViewer.Core/IntensityThemes/Quarog.axaml
@@ -1,35 +1,35 @@
-﻿<Styles xmlns="https://github.com/avaloniaui"
+<Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:system="clr-namespace:System;assembly=System.Runtime">
   <Styles.Resources>
-    <Color x:Key="UnknownForeground">#ffffff</Color>
-    <Color x:Key="UnknownBackground">#323c46</Color>
+    <Color x:Key="UnknownForeground">#F5FFFFFF</Color>
+    <Color x:Key="UnknownBackground">#1e2832</Color>
 
-    <Color x:Key="ErrorForeground">White</Color>
-    <Color x:Key="ErrorBackground">#505a64</Color>
+    <Color x:Key="ErrorForeground">#F5FFFFFF</Color>
+    <Color x:Key="ErrorBackground">#5a646e</Color>
 
-    <Color x:Key="Int0Foreground">#aab4be</Color>
-    <Color x:Key="Int0Background">#505a64</Color>
-    <Color x:Key="Int1Foreground">White</Color>
+    <Color x:Key="Int0Foreground">#F5a0aab4</Color>
+    <Color x:Key="Int0Background">#5a646e</Color>
+    <Color x:Key="Int1Foreground">#F5FFFFFF</Color>
     <Color x:Key="Int1Background">#325a8c</Color>
-    <Color x:Key="Int2Foreground">White</Color>
+    <Color x:Key="Int2Foreground">#F5FFFFFF</Color>
     <Color x:Key="Int2Background">#3278d2</Color>
-    <Color x:Key="Int3Foreground">#1e2832</Color>
+    <Color x:Key="Int3Foreground">#F51E2832</Color>
     <Color x:Key="Int3Background">#32d2e6</Color>
-    <Color x:Key="Int4Foreground">#1e2832</Color>
-    <Color x:Key="Int4Background">#f0f078</Color>
+    <Color x:Key="Int4Foreground">#F51e2832</Color>
+    <Color x:Key="Int4Background">#fafa8c</Color>
 
-    <Color x:Key="Int5LowerForeground">#1e2832</Color>
-    <Color x:Key="Int5LowerBackground">#fab428</Color>
-    <Color x:Key="Int5UpperForeground">#1e2832</Color>
-    <Color x:Key="Int5UpperBackground">#fa781e</Color>
+    <Color x:Key="Int5LowerForeground">#F51e2832</Color>
+    <Color x:Key="Int5LowerBackground">#fabe32</Color>
+    <Color x:Key="Int5UpperForeground">#F51e2832</Color>
+    <Color x:Key="Int5UpperBackground">#fa821e</Color>
 
-    <Color x:Key="Int6LowerForeground">White</Color>
-    <Color x:Key="Int6LowerBackground">#dc1e14</Color>
-    <Color x:Key="Int6UpperForeground">White</Color>
-    <Color x:Key="Int6UpperBackground">#8c140a</Color>
+    <Color x:Key="Int6LowerForeground">#F5FFFFFF</Color>
+    <Color x:Key="Int6LowerBackground">#e61414</Color>
+    <Color x:Key="Int6UpperForeground">#F5FFFFFF</Color>
+    <Color x:Key="Int6UpperBackground">#a01432</Color>
 
-    <Color x:Key="Int7Foreground">White</Color>
-    <Color x:Key="Int7Background">#500a64</Color>
+    <Color x:Key="Int7Foreground">#F5FFFFFF</Color>
+    <Color x:Key="Int7Background">#5a1446</Color>
   </Styles.Resources>
 </Styles>

--- a/src/KyoshinEewViewer.Core/Themes/Quarog.axaml
+++ b/src/KyoshinEewViewer.Core/Themes/Quarog.axaml
@@ -5,17 +5,17 @@
 		<SolidColorBrush x:Key="CopyrightBackgroundColor" Color="#66FFFFFF" />
 		<SolidColorBrush x:Key="CopyrightForegroundColor" Color="#000000" />
 
-		<Color x:Key="OverseasLandColor">#465a6e</Color>
+		<Color x:Key="OverseasLandColor">#64788c</Color>
 
-		<Color x:Key="LandStrokeColor">#8296aa</Color>
-		<Color x:Key="LandColor">#465a6e</Color>
+		<Color x:Key="LandStrokeColor">#a0b4c8</Color>
+		<Color x:Key="LandColor">#64788c</Color>
 
 		<system:Single x:Key="LandStrokeThickness">.9</system:Single>
 
-		<Color x:Key="PrefStrokeColor">#8296aa</Color>
+		<Color x:Key="PrefStrokeColor">#a0b4c8</Color>
 		<system:Single x:Key="PrefStrokeThickness">.8</system:Single>
 
-		<Color x:Key="AreaStrokeColor">#8296aa</Color>
+		<Color x:Key="AreaStrokeColor">#a0b4c8</Color>
 		<system:Single x:Key="AreaStrokeThickness">.4</system:Single>
 
 		<SolidColorBrush x:Key="MainBackgroundColor" Color="#1e3246" />
@@ -23,15 +23,15 @@
 		<SolidColorBrush x:Key="Foreground" Color="White" />
 		<Color x:Key="SubForegroundColor">White</Color>
 		<SolidColorBrush x:Key="SubForeground" Color="White" />
-		<SolidColorBrush x:Key="EmphasisForegroundColor" Color="#f0f078" />
-		<SolidColorBrush x:Key="DockBackgroundColor" Color="#DD3c4650" />
-		<SolidColorBrush x:Key="DockTitleBackgroundColor" Color="#DD505a64" />
+		<SolidColorBrush x:Key="EmphasisForegroundColor" Color="#fafa8c" />
+		<SolidColorBrush x:Key="DockBackgroundColor" Color="#DD323c46" />
+		<SolidColorBrush x:Key="DockTitleBackgroundColor" Color="#DD46505a" />
 
-		<SolidColorBrush x:Key="WarningForegroundColor" Color="#f0f078" />
-		<SolidColorBrush x:Key="WarningSubForegroundColor" Color="Khaki" />
-		<SolidColorBrush x:Key="WarningBackgroundColor" Color="#BB78828c" />
-		<SolidColorBrush x:Key="DockWarningTitleBackgroundColor" Color="#BBAA0000" />
-		<SolidColorBrush x:Key="DockWarningBackgroundColor" Color="#BBFF0000" />
+		<SolidColorBrush x:Key="WarningForegroundColor" Color="#fafa8c" />
+		<SolidColorBrush x:Key="WarningSubForegroundColor" Color="#fafa8c" />
+		<SolidColorBrush x:Key="WarningBackgroundColor" Color="#CC4b3835" />
+		<SolidColorBrush x:Key="DockWarningTitleBackgroundColor" Color="#CCb4321e" />
+		<SolidColorBrush x:Key="DockWarningBackgroundColor" Color="#CC37221f" />
 
 		<system:Boolean x:Key="IsDarkTheme">true</system:Boolean>
 		<Color x:Key="TitleBackgroundColor">#1e2832</Color>


### PR DESCRIPTION
震度アイコンテーマ及びウィンドウテーマの配色を変更しました。
![KyoshinEewViewer_ymPDBrs4cv](https://user-images.githubusercontent.com/78421096/211313713-0284c652-44e5-4bf6-9483-8a1d57267bbc.png)
![KyoshinEewViewer_p97QMwwTfl](https://user-images.githubusercontent.com/78421096/211313724-f430fc3c-2939-426a-8da8-6e70b10cb0d7.png)
