### PR TITLE
（Windows）通知のクリック時にメインウインドウを表示する

### DIFF
--- a/src/KyoshinEewViewer/Notification/Windows/NativeMethods.cs
+++ b/src/KyoshinEewViewer/Notification/Windows/NativeMethods.cs
@@ -70,6 +70,9 @@ internal static class NativeMethods
 	public const int WmLbuttondblclk = 0x0203;
 	public const int WmRbuttonup = 0x0205;
 
+	public const uint NinBalloonTimeout = 0x404;
+	public const uint NinBalloonUserclick = 0x405;
+
 	public const uint NimAdd = 0;
 	public const uint NimModify = 1;
 	public const uint NimDelete = 2;

--- a/src/KyoshinEewViewer/Notification/Windows/WindowsNotificationProvider.cs
+++ b/src/KyoshinEewViewer/Notification/Windows/WindowsNotificationProvider.cs
@@ -165,6 +165,11 @@ public class WindowsNotificationProvider : NotificationProvider
 			Dispatcher.UIThread.Post(() => MessageBus.Current.SendMessage(new ShowMainWindowRequested()));
 			return IntPtr.Zero;
 		}
+		if (lParam.ToInt32() == NinBalloonUserclick)
+		{
+			Dispatcher.UIThread.Post(() => MessageBus.Current.SendMessage(new ShowMainWindowRequested()));
+			return IntPtr.Zero;
+		}
 		if (lParam.ToInt32() != WmRbuttonup)
 			return DefWindowProc(hWnd, uMsg, wParam, lParam);
 		if (_hMenu == IntPtr.Zero)


### PR DESCRIPTION
KEVを最小化時にタスクトレイに追加・トレイアイコン非表示の設定にしていると、通知に気づいても画面を表示させるまでに数ステップかかっています。
トースト通知のクリック操作でメインウインドウを直接開く機能を追加してみました。

## 変更内容

- NativeMethods.cs
NIN_BALLOONTIMEOUT、NIN_BALLOONUSERCLICKの定義を追加しました。
- WindowsNotificationProvider.cs
ユーザーがトースト通知（☒以外の部分）をクリックした際に送信されるNIN_BALLOONUSERCLICKメッセージを受け取って、メインウインドウを表示する処理を追加しました。（トレイアイコン左クリックと同じ処理）


## 参考

https://learn.microsoft.com/en-us/windows/win32/api/shellapi/nf-shellapi-shell_notifyiconw