### PR TITLE
fix: ウィンドウテーマ変更時にミニマップの配色が更新されない

### DIFF
--- a/src/KyoshinEewViewer/Views/MainView.axaml.cs
+++ b/src/KyoshinEewViewer/Views/MainView.axaml.cs
@@ -18,7 +18,10 @@ public partial class MainView : UserControl
 		InitializeComponent();
 
 		KyoshinEewViewerApp.Selector?.WhenAnyValue(x => x.SelectedWindowTheme).Where(x => x != null)
-				.Subscribe(x => Map.RefreshResourceCache(x!.Theme));
+				.Subscribe(x => {
+					Map.RefreshResourceCache(x!.Theme);
+					MiniMap.RefreshResourceCache(x!.Theme);
+				});
 
 		var config = Locator.Current.RequireService<KyoshinEewViewerConfiguration>();
 		config.Map.WhenAnyValue(x => x.DisableManualMapControl).Subscribe(x =>


### PR DESCRIPTION
キャッシュが更新されていなかったためミニマップが更新されなかったので、ミニマップのキャッシュも更新されるようにしました