### PR TITLE
マルチウィンドウの座標保存を修正

### DIFF
--- a/src/KyoshinEewViewer.Core/Models/KyoshinEewViewerConfiguration.cs
+++ b/src/KyoshinEewViewer.Core/Models/KyoshinEewViewerConfiguration.cs
@@ -122,6 +122,16 @@ public class KyoshinEewViewerConfiguration : ReactiveObject
 	/// </summary>
 	public class SeriesWindowConfig : ReactiveObject
 	{
+		private bool _isOpen = true;
+		/// <summary>
+		/// 前回終了時にウィンドウが開いていたかどうか
+		/// </summary>
+		public bool IsOpen
+		{
+			get => _isOpen;
+			set => this.RaiseAndSetIfChanged(ref _isOpen, value);
+		}
+
 		private WindowState _windowState = WindowState.Normal;
 		public WindowState WindowState
 		{

--- a/src/KyoshinEewViewer.Desktop/Services/SubWindowsService.cs
+++ b/src/KyoshinEewViewer.Desktop/Services/SubWindowsService.cs
@@ -214,14 +214,17 @@ public class SubWindowsService : ISubWindowsService
 
 		if (config.MultiWindow.SeriesWindows.TryGetValue(series.Meta.Key, out var savedConfig))
 		{
-			if (savedConfig.WindowLocation is { } loc)
-				window.Position = new PixelPoint((int)loc.X, (int)loc.Y);
 			if (savedConfig.WindowSize is { } size)
 			{
 				window.Width = size.X;
 				window.Height = size.Y;
 			}
 			window.WindowState = savedConfig.WindowState;
+			if (savedConfig.WindowLocation is { } loc && loc.X != -32000 && loc.Y != -32000)
+			{
+				window.WindowStartupLocation = WindowStartupLocation.Manual;
+				window.Position = new PixelPoint((int)loc.X, (int)loc.Y);
+			}
 		}
 
 		var themeSubscription = Subscribe(window);
@@ -236,13 +239,14 @@ public class SubWindowsService : ISubWindowsService
 		.ObserveOn(RxApp.MainThreadScheduler)
 		.Subscribe(_ => SaveWindowConfig(series.Meta.Key, window, config));
 
-		window.Closed += (s, e) =>
-		{
+		window.Closing += (s, e) =>
 			SaveWindowConfig(series.Meta.Key, window, config);
 
-			// アプリケーション終了中でない場合のみ設定から削除
-			if (!IsShuttingDown)
-				config.MultiWindow.SeriesWindows.Remove(series.Meta.Key);
+		window.Closed += (s, e) =>
+		{
+			// アプリケーション終了中でない場合のみ「開いている」状態を解除
+			if (!IsShuttingDown && config.MultiWindow.SeriesWindows.TryGetValue(series.Meta.Key, out var windowConfig))
+				windowConfig.IsOpen = false;
 
 			positionSubscription?.Dispose();
 			themeSubscription.Dispose();
@@ -256,6 +260,7 @@ public class SubWindowsService : ISubWindowsService
 
 		if (!config.MultiWindow.SeriesWindows.ContainsKey(series.Meta.Key))
 			config.MultiWindow.SeriesWindows[series.Meta.Key] = new();
+		config.MultiWindow.SeriesWindows[series.Meta.Key].IsOpen = true;
 
 		viewModel.AttachToSeries();
 
@@ -273,10 +278,11 @@ public class SubWindowsService : ISubWindowsService
 			config.MultiWindow.SeriesWindows[key] = windowConfig;
 		}
 		windowConfig.WindowState = window.WindowState;
-		if (window.WindowState == WindowState.Normal)
+		if (window.WindowState is not WindowState.Minimized and not WindowState.FullScreen)
 		{
 			windowConfig.WindowLocation = new(window.Position.X, window.Position.Y);
-			windowConfig.WindowSize = new(window.Width, window.Height);
+			if (window.WindowState != WindowState.Maximized)
+				windowConfig.WindowSize = new(window.ClientSize.Width, window.ClientSize.Height);
 		}
 	}
 

--- a/src/KyoshinEewViewer/ViewModels/MainViewModel.cs
+++ b/src/KyoshinEewViewer/ViewModels/MainViewModel.cs
@@ -452,9 +452,12 @@ public partial class MainViewModel : ViewModelBase
 
 		Dispatcher.UIThread.Post(() =>
 		{
-			foreach (var key in Config.MultiWindow.SeriesWindows.Keys.ToArray())
+			foreach (var pair in Config.MultiWindow.SeriesWindows.ToArray())
 			{
-				var series = SeriesController.EnabledSeries.FirstOrDefault(s => s.Meta.Key == key);
+				if (!pair.Value.IsOpen)
+					continue;
+
+				var series = SeriesController.EnabledSeries.FirstOrDefault(s => s.Meta.Key == pair.Key);
 				if (series != null)
 				{
 					SubWindowsService.ShowSeriesWindow(series);


### PR DESCRIPTION
新しいマルチウィンドウ機能を試している中で、ウィンドウ位置が保存されていないことに気づきました。
調査のうえ、位置の保存・復元が正しく行われるよう修正しました。
また、起動時にマルチウィンドウを再表示するようにしました。不要であれば削除や設定化も検討できます。