### PR TITLE
[GitHub Actions] 3rd party actionsのバージョンを最新にする

### DIFF
--- a/.github/workflows/build_pidas-plus-graph.yml
+++ b/.github/workflows/build_pidas-plus-graph.yml
@@ -16,13 +16,13 @@ jobs:
     env:
       RELEASE_PREFIX: PiDASPlusGraph
     steps:
-    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         submodules: 'recursive'
     - uses: FranzDiebold/github-env-vars-action@e8118971bd6b60524ae66a2d870bc83088e3a3c9 # v2.9.0
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@871f041373faaad213a635d9afb62905ec029bbb # v1.10.1
+      uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
       with:
         dotnet-version: 10.0.x
 
@@ -44,7 +44,7 @@ jobs:
         chmod +x tmp/PiDASPlusGraph
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ env.RELEASE_PREFIX }}-${{ github.event.inputs.version }}-${{ matrix.os }}-${{ matrix.arch }}
         path: tmp/*

--- a/.github/workflows/build_pidas-plus-graph.yml
+++ b/.github/workflows/build_pidas-plus-graph.yml
@@ -16,13 +16,13 @@ jobs:
     env:
       RELEASE_PREFIX: PiDASPlusGraph
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       with:
         submodules: 'recursive'
-    - uses: FranzDiebold/github-env-vars-action@v2
+    - uses: FranzDiebold/github-env-vars-action@e8118971bd6b60524ae66a2d870bc83088e3a3c9 # v2.9.0
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@871f041373faaad213a635d9afb62905ec029bbb # v1.10.1
       with:
         dotnet-version: 10.0.x
 
@@ -44,7 +44,7 @@ jobs:
         chmod +x tmp/PiDASPlusGraph
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: ${{ env.RELEASE_PREFIX }}-${{ github.event.inputs.version }}-${{ matrix.os }}-${{ matrix.arch }}
         path: tmp/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,13 +15,13 @@ jobs:
     env:
       RELEASE_PREFIX: KyoshinEewViewer
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       with:
         submodules: 'recursive'
-    - uses: FranzDiebold/github-env-vars-action@v2
+    - uses: FranzDiebold/github-env-vars-action@e8118971bd6b60524ae66a2d870bc83088e3a3c9 # v2.9.0
     
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@871f041373faaad213a635d9afb62905ec029bbb # v1.10.1
       with:
         dotnet-version: 10.0.x
     
@@ -75,13 +75,13 @@ jobs:
       run: move tmp/KyoshinEewViewer.Desktop.exe tmp/KyoshinEewViewer.exe
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: ${{ env.RELEASE_PREFIX }}-${{ matrix.os }}-${{ matrix.arch }}
         path: tmp/*
 
     - name: Archive
-      uses: TheDoctor0/zip-release@0.6.0
+      uses: TheDoctor0/zip-release@4fb9e4ff72847dd3d1c111cf63834e353ed7cb3d # 0.6.0
       if: startsWith(github.ref, 'refs/tags/')
       with:
         type: 'zip'
@@ -90,7 +90,7 @@ jobs:
         filename: ../${{ env.RELEASE_PREFIX }}-${{ matrix.os }}-${{ matrix.arch }}.zip
 
     - name: Upload release assets
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       if: startsWith(github.ref, 'refs/tags/')
       with:
         name: release-${{ matrix.os }}-${{ matrix.arch }}
@@ -104,13 +104,13 @@ jobs:
     env:
       RELEASE_PREFIX: KyoshinEewViewer
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       with:
         submodules: 'recursive'
-    - uses: FranzDiebold/github-env-vars-action@v2
+    - uses: FranzDiebold/github-env-vars-action@e8118971bd6b60524ae66a2d870bc83088e3a3c9 # v2.9.0
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@871f041373faaad213a635d9afb62905ec029bbb # v1.10.1
       with:
         dotnet-version: 10.0.x
 
@@ -164,13 +164,13 @@ jobs:
         APP_VERSION: ${{ (contains(github.ref, 'tags/') && env.CI_ACTION_REF_NAME) || '0.1.1' }}
     
     - name: Upload artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: ${{ env.RELEASE_PREFIX }}-macos-${{ matrix.arch }}
         path: tmp2/*
 
     - name: Archive
-      uses: TheDoctor0/zip-release@0.6.0
+      uses: TheDoctor0/zip-release@4fb9e4ff72847dd3d1c111cf63834e353ed7cb3d # 0.6.0
       if: startsWith(github.ref, 'refs/tags/')
       with:
         type: 'zip'
@@ -179,7 +179,7 @@ jobs:
         filename: ../${{ env.RELEASE_PREFIX }}-macos-${{ matrix.arch }}.zip
 
     - name: Upload release assets
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       if: startsWith(github.ref, 'refs/tags/')
       with:
         name: release-macos-${{ matrix.arch }}
@@ -190,17 +190,17 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     steps:
-    - uses: FranzDiebold/github-env-vars-action@v2
+    - uses: FranzDiebold/github-env-vars-action@e8118971bd6b60524ae66a2d870bc83088e3a3c9 # v2.9.0
 
     - name: Download all release assets
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       with:
         pattern: release-*
         path: release-assets
         merge-multiple: true
 
     - name: Create Release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15
       with:
         files: release-assets/*
         name: v${{ env.CI_ACTION_REF_NAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,13 +15,13 @@ jobs:
     env:
       RELEASE_PREFIX: KyoshinEewViewer
     steps:
-    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         submodules: 'recursive'
     - uses: FranzDiebold/github-env-vars-action@e8118971bd6b60524ae66a2d870bc83088e3a3c9 # v2.9.0
     
     - name: Setup .NET
-      uses: actions/setup-dotnet@871f041373faaad213a635d9afb62905ec029bbb # v1.10.1
+      uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
       with:
         dotnet-version: 10.0.x
     
@@ -75,13 +75,13 @@ jobs:
       run: move tmp/KyoshinEewViewer.Desktop.exe tmp/KyoshinEewViewer.exe
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ env.RELEASE_PREFIX }}-${{ matrix.os }}-${{ matrix.arch }}
         path: tmp/*
 
     - name: Archive
-      uses: TheDoctor0/zip-release@4fb9e4ff72847dd3d1c111cf63834e353ed7cb3d # 0.6.0
+      uses: TheDoctor0/zip-release@b57d897cb5d60cb78b51a507f63fa184cfe35554 # 0.7.6
       if: startsWith(github.ref, 'refs/tags/')
       with:
         type: 'zip'
@@ -90,7 +90,7 @@ jobs:
         filename: ../${{ env.RELEASE_PREFIX }}-${{ matrix.os }}-${{ matrix.arch }}.zip
 
     - name: Upload release assets
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: startsWith(github.ref, 'refs/tags/')
       with:
         name: release-${{ matrix.os }}-${{ matrix.arch }}
@@ -104,13 +104,13 @@ jobs:
     env:
       RELEASE_PREFIX: KyoshinEewViewer
     steps:
-    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         submodules: 'recursive'
     - uses: FranzDiebold/github-env-vars-action@e8118971bd6b60524ae66a2d870bc83088e3a3c9 # v2.9.0
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@871f041373faaad213a635d9afb62905ec029bbb # v1.10.1
+      uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
       with:
         dotnet-version: 10.0.x
 
@@ -164,13 +164,13 @@ jobs:
         APP_VERSION: ${{ (contains(github.ref, 'tags/') && env.CI_ACTION_REF_NAME) || '0.1.1' }}
     
     - name: Upload artifacts
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ env.RELEASE_PREFIX }}-macos-${{ matrix.arch }}
         path: tmp2/*
 
     - name: Archive
-      uses: TheDoctor0/zip-release@4fb9e4ff72847dd3d1c111cf63834e353ed7cb3d # 0.6.0
+      uses: TheDoctor0/zip-release@b57d897cb5d60cb78b51a507f63fa184cfe35554 # 0.7.6
       if: startsWith(github.ref, 'refs/tags/')
       with:
         type: 'zip'
@@ -179,7 +179,7 @@ jobs:
         filename: ../${{ env.RELEASE_PREFIX }}-macos-${{ matrix.arch }}.zip
 
     - name: Upload release assets
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: startsWith(github.ref, 'refs/tags/')
       with:
         name: release-macos-${{ matrix.arch }}
@@ -193,14 +193,14 @@ jobs:
     - uses: FranzDiebold/github-env-vars-action@e8118971bd6b60524ae66a2d870bc83088e3a3c9 # v2.9.0
 
     - name: Download all release assets
-      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         pattern: release-*
         path: release-assets
         merge-multiple: true
 
     - name: Create Release
-      uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15
+      uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
       with:
         files: release-assets/*
         name: v${{ env.CI_ACTION_REF_NAME }}

--- a/.github/workflows/update-homebrew-cask.yml
+++ b/.github/workflows/update-homebrew-cask.yml
@@ -15,7 +15,7 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       with:
         fetch-depth: 0
 
@@ -86,7 +86,7 @@ jobs:
 
     - name: Clone homebrew-tap repository
       if: steps.dryrun.outputs.is_dryrun == 'false'
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       with:
         repository: ingen084/homebrew-tap
         path: homebrew-tap

--- a/.github/workflows/update-homebrew-cask.yml
+++ b/.github/workflows/update-homebrew-cask.yml
@@ -15,7 +15,7 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 0
 
@@ -86,7 +86,7 @@ jobs:
 
     - name: Clone homebrew-tap repository
       if: steps.dryrun.outputs.is_dryrun == 'false'
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: ingen084/homebrew-tap
         path: homebrew-tap


### PR DESCRIPTION
> [!NOTE]
> - #172 を先にマージしてください

- closes #173 

## 概要

- 古い3rd party actionを使い続けることは、パフォーマンスやセキュリティの観点から懸念がある
  - また、[Deprecation of Node 20 on GitHub Actions runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)に記載の通り、既にNode20の利用は非推奨となっており、2026年6月2日よりNode24をデフォルトで利用するようになる
    - これらのランタイム更新に対応したバージョンに上げるべき

上げたバージョンのchangelogや評価はIssueを参照してください。