### PR TITLE
自動ズームを無効化したときにメインウィンドウでホームボタンが機能しない問題を修正

### DIFF
--- a/src/KyoshinEewViewer/ViewModels/MainViewModel.cs
+++ b/src/KyoshinEewViewer/ViewModels/MainViewModel.cs
@@ -420,7 +420,7 @@ public partial class MainViewModel : ViewModelBase
 	}
 
 	public void ReturnToHomeMap()
-		=> MessageBus.Current.SendMessage(SelectedSeries?.MapNavigationRequest ?? new MapNavigationRequest(null));
+		=> MessageBus.Current.SendMessage(new MainViewMapNavigationRequest(SelectedSeries?.MapNavigationRequest ?? new MapNavigationRequest(null)));
 
 	public void ToggleMute()
 		=> Config.Audio.IsMuted = !Config.Audio.IsMuted;
@@ -459,3 +459,8 @@ public partial class MainViewModel : ViewModelBase
 		});
 	}
 }
+
+/// <summary>
+/// MainView専用のマップナビゲーションリクエスト
+/// </summary>
+public record MainViewMapNavigationRequest(MapNavigationRequest? Request);

--- a/src/KyoshinEewViewer/ViewModels/MainViewModel.cs
+++ b/src/KyoshinEewViewer/ViewModels/MainViewModel.cs
@@ -419,9 +419,6 @@ public partial class MainViewModel : ViewModelBase
 		return true;
 	}
 
-	public void ReturnToHomeMap()
-		=> MessageBus.Current.SendMessage(new MainViewMapNavigationRequest(SelectedSeries?.MapNavigationRequest ?? new MapNavigationRequest(null)));
-
 	public void ToggleMute()
 		=> Config.Audio.IsMuted = !Config.Audio.IsMuted;
 
@@ -459,8 +456,3 @@ public partial class MainViewModel : ViewModelBase
 		});
 	}
 }
-
-/// <summary>
-/// MainView専用のマップナビゲーションリクエスト
-/// </summary>
-public record MainViewMapNavigationRequest(MapNavigationRequest? Request);

--- a/src/KyoshinEewViewer/Views/MainView.axaml
+++ b/src/KyoshinEewViewer/Views/MainView.axaml
@@ -239,7 +239,7 @@
                             <ui:FASymbolIcon Symbol="{Binding Config.Audio.IsMuted, Converter={x:Static converter:BoolToStringConverter.VolumeIcon}}" Classes.muted="{Binding Config.Audio.IsMuted}" />
                         </Viewbox>
                     </Button>
-                    <Button Name="HomeButton" Command="{Binding ReturnToHomeMap}" Padding="10,7" Theme="{StaticResource TransparentButton}" ToolTip.Tip="地図の座標を戻す">
+                    <Button Name="HomeButton" Click="HomeButton_Click" Padding="10,7" Theme="{StaticResource TransparentButton}" ToolTip.Tip="地図の座標を戻す">
                         <Viewbox Height="28" Margin="0,2">
                             <ui:FASymbolIcon Symbol="Home" />
                         </Viewbox>

--- a/src/KyoshinEewViewer/Views/MainView.axaml.cs
+++ b/src/KyoshinEewViewer/Views/MainView.axaml.cs
@@ -4,6 +4,7 @@ using KyoshinEewViewer.Core;
 using KyoshinEewViewer.Core.Models;
 using KyoshinEewViewer.Core.Models.Events;
 using KyoshinEewViewer.Map;
+using KyoshinEewViewer.ViewModels;
 using ReactiveUI;
 using SkiaSharp;
 using Splat;
@@ -57,16 +58,10 @@ public partial class MainView : UserControl
 		{
 			if (!config.Map.AutoFocus)
 				return;
-			if (x?.Bound is { } rect)
-			{
-				if (x.MustBound is { } mustBound)
-					Map.Navigate(rect, config.Map.AutoFocusAnimation ? TimeSpan.FromSeconds(.3) : TimeSpan.Zero, mustBound);
-				else
-					Map.Navigate(rect, config.Map.AutoFocusAnimation ? TimeSpan.FromSeconds(.3) : TimeSpan.Zero);
-			}
-			else
-				NavigateToHome();
+			NavigateMap(x, config);
 		});
+		MessageBus.Current.Listen<MainViewMapNavigationRequest>().Subscribe(x => NavigateMap(x.Request, config));
+
 		MessageBus.Current.Listen<RegistMapPositionRequested>().Subscribe(x =>
 		{
 			var halfPaddedRect = new PointD(Map.PaddedRect.Width / 2, -Map.PaddedRect.Height / 2);
@@ -100,9 +95,21 @@ public partial class MainView : UserControl
 		MiniMap.Navigate(new RectD(new PointD(22.289, 121.207), new PointD(31.128, 132.100)), TimeSpan.Zero, true);
 	}
 
-	private void NavigateToHome()
+	private void NavigateMap(MapNavigationRequest? request, KyoshinEewViewerConfiguration config)
 	{
-		var config = Locator.Current.RequireService<KyoshinEewViewerConfiguration>();
+		if (request?.Bound is { } rect)
+		{
+			if (request.MustBound is { } mustBound)
+				Map.Navigate(rect, config.Map.AutoFocusAnimation ? TimeSpan.FromSeconds(.3) : TimeSpan.Zero, mustBound);
+			else
+				Map.Navigate(rect, config.Map.AutoFocusAnimation ? TimeSpan.FromSeconds(.3) : TimeSpan.Zero);
+		}
+		else
+			NavigateToHome(config);
+	}
+
+	private void NavigateToHome(KyoshinEewViewerConfiguration config)
+	{
 		Map?.Navigate(
 			new RectD(config.Map.Location1.CastPoint(), config.Map.Location2.CastPoint()),
 			config.Map.AutoFocusAnimation ? TimeSpan.FromSeconds(.3) : TimeSpan.Zero);

--- a/src/KyoshinEewViewer/Views/MainView.axaml.cs
+++ b/src/KyoshinEewViewer/Views/MainView.axaml.cs
@@ -1,4 +1,5 @@
 using Avalonia.Controls;
+using Avalonia.Interactivity;
 using Avalonia.Threading;
 using KyoshinEewViewer.Core;
 using KyoshinEewViewer.Core.Models;
@@ -60,7 +61,6 @@ public partial class MainView : UserControl
 				return;
 			NavigateMap(x, config);
 		});
-		MessageBus.Current.Listen<MainViewMapNavigationRequest>().Subscribe(x => NavigateMap(x.Request, config));
 
 		MessageBus.Current.Listen<RegistMapPositionRequested>().Subscribe(x =>
 		{
@@ -93,6 +93,13 @@ public partial class MainView : UserControl
 			return;
 		//MiniMap.Navigate(new RectD(new PointD(24.127, 123.585), new PointD(28.546, 129.803)), TimeSpan.Zero, true);
 		MiniMap.Navigate(new RectD(new PointD(22.289, 121.207), new PointD(31.128, 132.100)), TimeSpan.Zero, true);
+	}
+
+	private void HomeButton_Click(object? sender, RoutedEventArgs e)
+	{
+		var config = Locator.Current.RequireService<KyoshinEewViewerConfiguration>();
+		var request = (DataContext as MainViewModel)?.SelectedSeries?.MapNavigationRequest ?? new MapNavigationRequest(null);
+		NavigateMap(request, config);
 	}
 
 	private void NavigateMap(MapNavigationRequest? request, KyoshinEewViewerConfiguration config)


### PR DESCRIPTION
**Summary**
- Wrap `ReturnToHomeMap` navigation in a `MainViewMapNavigationRequest` so the main view can distinguish home-map requests from regular map navigation.
- Consolidate map navigation handling in `MainView` with a shared helper that either navigates to the requested bounds or falls back to the home map.
- Pass the configuration through the helper to avoid re-resolving it during home navigation.

**Testing**
- Not run (not requested)