### PR TITLE
fix: テストのReactiveUI初期化とDIモックの不一致を修正

### DIFF
--- a/tests/KyoshinEewViewer.Tests/Services/TelegramProvideServiceConcurrencyTests.cs
+++ b/tests/KyoshinEewViewer.Tests/Services/TelegramProvideServiceConcurrencyTests.cs
@@ -43,7 +43,7 @@ public TelegramProvideServiceConcurrencyTests()
 
 		var customTypes = new[] { typeof(MockTelegramPublisher) };
 
-		_mockServiceProvider.Setup(x => x.GetService(typeof(MockTelegramPublisher), null))
+		_mockServiceProvider.Setup(x => x.GetService(typeof(MockTelegramPublisher)))
 			.Returns(publisher);
 
 		var receivedTelegrams = new ConcurrentBag<Telegram>();
@@ -110,7 +110,7 @@ public TelegramProvideServiceConcurrencyTests()
 			typeof(MockTelegramPublisher)
 		};
 
-		_mockServiceProvider.SetupSequence(x => x.GetService(typeof(MockTelegramPublisher), null))
+		_mockServiceProvider.SetupSequence(x => x.GetService(typeof(MockTelegramPublisher)))
 			.Returns(primary)
 			.Returns(secondary);
 
@@ -181,7 +181,7 @@ public TelegramProvideServiceConcurrencyTests()
 
 		var customTypes = new[] { typeof(MockTelegramPublisher) };
 
-		_mockServiceProvider.Setup(x => x.GetService(typeof(MockTelegramPublisher), null))
+		_mockServiceProvider.Setup(x => x.GetService(typeof(MockTelegramPublisher)))
 			.Returns(publisher);
 
 		_service.Subscribe(
@@ -246,7 +246,7 @@ public TelegramProvideServiceConcurrencyTests()
 
 		var customTypes = new[] { typeof(MockTelegramPublisher) };
 
-		_mockServiceProvider.Setup(x => x.GetService(typeof(MockTelegramPublisher), null))
+		_mockServiceProvider.Setup(x => x.GetService(typeof(MockTelegramPublisher)))
 			.Returns(publisher);
 
 		var subscriberCount = 5;
@@ -314,7 +314,7 @@ public TelegramProvideServiceConcurrencyTests()
 			typeof(MockTelegramPublisher)
 		};
 
-		_mockServiceProvider.SetupSequence(x => x.GetService(typeof(MockTelegramPublisher), null))
+		_mockServiceProvider.SetupSequence(x => x.GetService(typeof(MockTelegramPublisher)))
 			.Returns(publisher1)
 			.Returns(publisher2);
 

--- a/tests/KyoshinEewViewer.Tests/Services/TelegramProvideServiceEdgeCaseTests.cs
+++ b/tests/KyoshinEewViewer.Tests/Services/TelegramProvideServiceEdgeCaseTests.cs
@@ -42,7 +42,7 @@ public TelegramProvideServiceEdgeCaseTests()
 
 		var customTypes = new[] { typeof(MockTelegramPublisher) };
 
-		_mockServiceProvider.Setup(x => x.GetService(typeof(MockTelegramPublisher), null))
+		_mockServiceProvider.Setup(x => x.GetService(typeof(MockTelegramPublisher)))
 			.Returns(universalPublisher);
 
 		// すべてのカテゴリをサブスクライブ
@@ -83,7 +83,7 @@ public TelegramProvideServiceEdgeCaseTests()
 
 		var customTypes = new[] { typeof(MockTelegramPublisher) };
 
-		_mockServiceProvider.Setup(x => x.GetService(typeof(MockTelegramPublisher), null))
+		_mockServiceProvider.Setup(x => x.GetService(typeof(MockTelegramPublisher)))
 			.Returns(publisher);
 
 		// Act - サブスクライバーなしでStart
@@ -107,7 +107,7 @@ public TelegramProvideServiceEdgeCaseTests()
 
 		var customTypes = new[] { typeof(MockTelegramPublisher) };
 
-		_mockServiceProvider.Setup(x => x.GetService(typeof(MockTelegramPublisher), null))
+		_mockServiceProvider.Setup(x => x.GetService(typeof(MockTelegramPublisher)))
 			.Returns(publisher);
 
 		var callCount = 0;
@@ -163,7 +163,7 @@ public TelegramProvideServiceEdgeCaseTests()
 			typeof(MockTelegramPublisher)
 		};
 
-		_mockServiceProvider.SetupSequence(x => x.GetService(typeof(MockTelegramPublisher), null))
+		_mockServiceProvider.SetupSequence(x => x.GetService(typeof(MockTelegramPublisher)))
 			.Returns(emptyPublisher)
 			.Returns(workingPublisher);
 
@@ -196,7 +196,7 @@ public TelegramProvideServiceEdgeCaseTests()
 
 		var customTypes = new[] { typeof(MockTelegramPublisher) };
 
-		_mockServiceProvider.Setup(x => x.GetService(typeof(MockTelegramPublisher), null))
+		_mockServiceProvider.Setup(x => x.GetService(typeof(MockTelegramPublisher)))
 			.Returns(longNamePublisher);
 
 		string? receivedSourceName = null;
@@ -239,7 +239,7 @@ public TelegramProvideServiceEdgeCaseTests()
 
 		var customTypes = new[] { typeof(MockTelegramPublisher) };
 
-		_mockServiceProvider.Setup(x => x.GetService(typeof(MockTelegramPublisher), null))
+		_mockServiceProvider.Setup(x => x.GetService(typeof(MockTelegramPublisher)))
 			.Returns(publisher);
 
 		var receivedTelegrams = new List<Telegram>();
@@ -291,7 +291,7 @@ public TelegramProvideServiceEdgeCaseTests()
 
 		var customTypes = new[] { typeof(MockTelegramPublisher) };
 
-		_mockServiceProvider.Setup(x => x.GetService(typeof(MockTelegramPublisher), null))
+		_mockServiceProvider.Setup(x => x.GetService(typeof(MockTelegramPublisher)))
 			.Returns(publisher);
 
 		_service.Subscribe(
@@ -354,7 +354,7 @@ public TelegramProvideServiceEdgeCaseTests()
 
 		var customTypes = new[] { typeof(MockTelegramPublisher) };
 
-		_mockServiceProvider.Setup(x => x.GetService(typeof(MockTelegramPublisher), null))
+		_mockServiceProvider.Setup(x => x.GetService(typeof(MockTelegramPublisher)))
 			.Returns(publisher);
 
 		var receivedCount = 0;
@@ -399,7 +399,7 @@ public TelegramProvideServiceEdgeCaseTests()
 
 		var customTypes = Enumerable.Repeat(typeof(MockTelegramPublisher), 50).ToArray();
 
-		_mockServiceProvider.Setup(x => x.GetService(typeof(MockTelegramPublisher), null))
+		_mockServiceProvider.Setup(x => x.GetService(typeof(MockTelegramPublisher)))
 			.Returns(() =>
 			{
 				var callCount = _mockServiceProvider.Invocations.Count(i => i.Method.Name == nameof(IReadonlyDependencyResolver.GetService));

--- a/tests/KyoshinEewViewer.Tests/Services/TelegramProvideServiceErrorHandlingTests.cs
+++ b/tests/KyoshinEewViewer.Tests/Services/TelegramProvideServiceErrorHandlingTests.cs
@@ -42,7 +42,7 @@ public TelegramProvideServiceErrorHandlingTests()
 
 		var customTypes = new[] { typeof(MockTelegramPublisher) };
 
-		_mockServiceProvider.Setup(x => x.GetService(typeof(MockTelegramPublisher), null))
+		_mockServiceProvider.Setup(x => x.GetService(typeof(MockTelegramPublisher)))
 			.Returns(publisher);
 
 		var goodSubscriberCalled = false;
@@ -96,7 +96,7 @@ public TelegramProvideServiceErrorHandlingTests()
 
 		var customTypes = new[] { typeof(MockTelegramPublisher) };
 
-		_mockServiceProvider.Setup(x => x.GetService(typeof(MockTelegramPublisher), null))
+		_mockServiceProvider.Setup(x => x.GetService(typeof(MockTelegramPublisher)))
 			.Returns(publisher);
 
 		var goodSubscriberCalled = false;
@@ -162,7 +162,7 @@ public TelegramProvideServiceErrorHandlingTests()
 			typeof(MockTelegramPublisher)
 		};
 
-		_mockServiceProvider.SetupSequence(x => x.GetService(typeof(MockTelegramPublisher), null))
+		_mockServiceProvider.SetupSequence(x => x.GetService(typeof(MockTelegramPublisher)))
 			.Returns(failingPublisher)
 			.Returns(workingPublisher);
 
@@ -200,7 +200,7 @@ public TelegramProvideServiceErrorHandlingTests()
 			typeof(MockTelegramPublisher)
 		};
 
-		_mockServiceProvider.SetupSequence(x => x.GetService(typeof(MockTelegramPublisher), null))
+		_mockServiceProvider.SetupSequence(x => x.GetService(typeof(MockTelegramPublisher)))
 			.Returns(failingPublisher)
 			.Returns(workingPublisher);
 
@@ -248,7 +248,7 @@ public TelegramProvideServiceErrorHandlingTests()
 			typeof(MockTelegramPublisher)
 		};
 
-		_mockServiceProvider.SetupSequence(x => x.GetService(typeof(MockTelegramPublisher), null))
+		_mockServiceProvider.SetupSequence(x => x.GetService(typeof(MockTelegramPublisher)))
 			.Returns(failingPublisher)
 			.Returns(workingPublisher);
 
@@ -305,7 +305,7 @@ public TelegramProvideServiceErrorHandlingTests()
 			typeof(MockTelegramPublisher)
 		};
 
-		_mockServiceProvider.SetupSequence(x => x.GetService(typeof(MockTelegramPublisher), null))
+		_mockServiceProvider.SetupSequence(x => x.GetService(typeof(MockTelegramPublisher)))
 			.Returns((MockTelegramPublisher?)null) // 最初のPublisherがnull
 			.Returns(workingPublisher);
 
@@ -344,7 +344,7 @@ public TelegramProvideServiceErrorHandlingTests()
 			typeof(MockTelegramPublisher)
 		};
 
-		_mockServiceProvider.Setup(x => x.GetService(typeof(MockTelegramPublisher), null))
+		_mockServiceProvider.Setup(x => x.GetService(typeof(MockTelegramPublisher)))
 			.Returns((MockTelegramPublisher?)null);
 
 		var failureReported = false;
@@ -377,7 +377,7 @@ public TelegramProvideServiceErrorHandlingTests()
 
 		var customTypes = new[] { typeof(MockTelegramPublisher) };
 
-		_mockServiceProvider.Setup(x => x.GetService(typeof(MockTelegramPublisher), null))
+		_mockServiceProvider.Setup(x => x.GetService(typeof(MockTelegramPublisher)))
 			.Returns(problematicPublisher);
 
 		var failureCount = 0;
@@ -417,7 +417,7 @@ public TelegramProvideServiceErrorHandlingTests()
 
 		var customTypes = new[] { typeof(MockTelegramPublisher) };
 
-		_mockServiceProvider.Setup(x => x.GetService(typeof(MockTelegramPublisher), null))
+		_mockServiceProvider.Setup(x => x.GetService(typeof(MockTelegramPublisher)))
 			.Returns(publisher);
 
 		var receivedTelegrams = new List<Telegram>();

--- a/tests/KyoshinEewViewer.Tests/Services/TelegramProvideServiceFallbackTests.cs
+++ b/tests/KyoshinEewViewer.Tests/Services/TelegramProvideServiceFallbackTests.cs
@@ -51,7 +51,7 @@ public TelegramProvideServiceFallbackTests()
 			typeof(MockTelegramPublisher)  // Secondary
 		};
 
-		_mockServiceProvider.SetupSequence(x => x.GetService(typeof(MockTelegramPublisher), null))
+		_mockServiceProvider.SetupSequence(x => x.GetService(typeof(MockTelegramPublisher)))
 			.Returns(primaryPublisher)
 			.Returns(secondaryPublisher);
 
@@ -120,7 +120,7 @@ public TelegramProvideServiceFallbackTests()
 			typeof(MockTelegramPublisher)
 		};
 
-		_mockServiceProvider.SetupSequence(x => x.GetService(typeof(MockTelegramPublisher), null))
+		_mockServiceProvider.SetupSequence(x => x.GetService(typeof(MockTelegramPublisher)))
 			.Returns(primaryPublisher)
 			.Returns(secondaryPublisher);
 
@@ -191,7 +191,7 @@ public TelegramProvideServiceFallbackTests()
 			typeof(MockTelegramPublisher)
 		};
 
-		_mockServiceProvider.SetupSequence(x => x.GetService(typeof(MockTelegramPublisher), null))
+		_mockServiceProvider.SetupSequence(x => x.GetService(typeof(MockTelegramPublisher)))
 			.Returns(primaryPublisher)
 			.Returns(secondaryPublisher);
 
@@ -230,7 +230,7 @@ public TelegramProvideServiceFallbackTests()
 			typeof(MockTelegramPublisher)
 		};
 
-		_mockServiceProvider.SetupSequence(x => x.GetService(typeof(MockTelegramPublisher), null))
+		_mockServiceProvider.SetupSequence(x => x.GetService(typeof(MockTelegramPublisher)))
 			.Returns(publisher1)
 			.Returns(publisher2)
 			.Returns(publisher3);
@@ -288,7 +288,7 @@ public TelegramProvideServiceFallbackTests()
 			typeof(MockTelegramPublisher)
 		};
 
-		_mockServiceProvider.SetupSequence(x => x.GetService(typeof(MockTelegramPublisher), null))
+		_mockServiceProvider.SetupSequence(x => x.GetService(typeof(MockTelegramPublisher)))
 			.Returns(primaryPublisher)
 			.Returns(secondaryPublisher);
 
@@ -344,7 +344,7 @@ public TelegramProvideServiceFallbackTests()
 			typeof(MockTelegramPublisher)
 		};
 
-		_mockServiceProvider.SetupSequence(x => x.GetService(typeof(MockTelegramPublisher), null))
+		_mockServiceProvider.SetupSequence(x => x.GetService(typeof(MockTelegramPublisher)))
 			.Returns(primaryPublisher)
 			.Returns(secondaryPublisher);
 

--- a/tests/KyoshinEewViewer.Tests/Services/TelegramProvideServiceHistoryTests.cs
+++ b/tests/KyoshinEewViewer.Tests/Services/TelegramProvideServiceHistoryTests.cs
@@ -42,7 +42,7 @@ public TelegramProvideServiceHistoryTests()
 
 		var customTypes = new[] { typeof(MockTelegramPublisher) };
 
-		_mockServiceProvider.Setup(x => x.GetService(typeof(MockTelegramPublisher), null))
+		_mockServiceProvider.Setup(x => x.GetService(typeof(MockTelegramPublisher)))
 			.Returns(publisher);
 
 		var sourceSwitchedCalled = false;
@@ -97,7 +97,7 @@ public TelegramProvideServiceHistoryTests()
 
 		var customTypes = new[] { typeof(MockTelegramPublisher) };
 
-		_mockServiceProvider.Setup(x => x.GetService(typeof(MockTelegramPublisher), null))
+		_mockServiceProvider.Setup(x => x.GetService(typeof(MockTelegramPublisher)))
 			.Returns(publisher);
 
 		var subscriber1Called = false;
@@ -163,7 +163,7 @@ public TelegramProvideServiceHistoryTests()
 
 		var customTypes = new[] { typeof(MockTelegramPublisher) };
 
-		_mockServiceProvider.Setup(x => x.GetService(typeof(MockTelegramPublisher), null))
+		_mockServiceProvider.Setup(x => x.GetService(typeof(MockTelegramPublisher)))
 			.Returns(publisher);
 
 		var earthquakeSourceSwitched = false;
@@ -219,7 +219,7 @@ public TelegramProvideServiceHistoryTests()
 
 		var customTypes = new[] { typeof(MockTelegramPublisher) };
 
-		_mockServiceProvider.Setup(x => x.GetService(typeof(MockTelegramPublisher), null))
+		_mockServiceProvider.Setup(x => x.GetService(typeof(MockTelegramPublisher)))
 			.Returns(publisher);
 
 		var sourceSwitchedCalled = false;
@@ -271,7 +271,7 @@ public TelegramProvideServiceHistoryTests()
 			typeof(MockTelegramPublisher)
 		};
 
-		_mockServiceProvider.SetupSequence(x => x.GetService(typeof(MockTelegramPublisher), null))
+		_mockServiceProvider.SetupSequence(x => x.GetService(typeof(MockTelegramPublisher)))
 			.Returns(primary)
 			.Returns(secondary);
 
@@ -338,7 +338,7 @@ public TelegramProvideServiceHistoryTests()
 			typeof(MockTelegramPublisher)
 		};
 
-		_mockServiceProvider.SetupSequence(x => x.GetService(typeof(MockTelegramPublisher), null))
+		_mockServiceProvider.SetupSequence(x => x.GetService(typeof(MockTelegramPublisher)))
 			.Returns(activePublisher)
 			.Returns(inactivePublisher);
 
@@ -391,7 +391,7 @@ public TelegramProvideServiceHistoryTests()
 
 		var customTypes = new[] { typeof(MockTelegramPublisher) };
 
-		_mockServiceProvider.Setup(x => x.GetService(typeof(MockTelegramPublisher), null))
+		_mockServiceProvider.Setup(x => x.GetService(typeof(MockTelegramPublisher)))
 			.Returns(publisher);
 
 		var sourceSwitchedCalled = false;

--- a/tests/KyoshinEewViewer.Tests/Services/TelegramProvideServiceRecoveryTests.cs
+++ b/tests/KyoshinEewViewer.Tests/Services/TelegramProvideServiceRecoveryTests.cs
@@ -51,7 +51,7 @@ public TelegramProvideServiceRecoveryTests()
 			typeof(MockTelegramPublisher)  // Secondary (優先度2)
 		};
 
-		_mockServiceProvider.SetupSequence(x => x.GetService(typeof(MockTelegramPublisher), null))
+		_mockServiceProvider.SetupSequence(x => x.GetService(typeof(MockTelegramPublisher)))
 			.Returns(primaryPublisher)
 			.Returns(secondaryPublisher);
 
@@ -100,7 +100,7 @@ public TelegramProvideServiceRecoveryTests()
 			typeof(MockTelegramPublisher)
 		};
 
-		_mockServiceProvider.SetupSequence(x => x.GetService(typeof(MockTelegramPublisher), null))
+		_mockServiceProvider.SetupSequence(x => x.GetService(typeof(MockTelegramPublisher)))
 			.Returns(primaryPublisher)
 			.Returns(secondaryPublisher);
 
@@ -166,7 +166,7 @@ public TelegramProvideServiceRecoveryTests()
 			typeof(MockTelegramPublisher)
 		};
 
-		_mockServiceProvider.SetupSequence(x => x.GetService(typeof(MockTelegramPublisher), null))
+		_mockServiceProvider.SetupSequence(x => x.GetService(typeof(MockTelegramPublisher)))
 			.Returns(primaryPublisher)
 			.Returns(secondaryPublisher);
 
@@ -221,7 +221,7 @@ public TelegramProvideServiceRecoveryTests()
 			typeof(MockTelegramPublisher)  // 最低優先度
 		};
 
-		_mockServiceProvider.SetupSequence(x => x.GetService(typeof(MockTelegramPublisher), null))
+		_mockServiceProvider.SetupSequence(x => x.GetService(typeof(MockTelegramPublisher)))
 			.Returns(publisher1)
 			.Returns(publisher2)
 			.Returns(publisher3);
@@ -278,7 +278,7 @@ public TelegramProvideServiceRecoveryTests()
 			typeof(MockTelegramPublisher)
 		};
 
-		_mockServiceProvider.SetupSequence(x => x.GetService(typeof(MockTelegramPublisher), null))
+		_mockServiceProvider.SetupSequence(x => x.GetService(typeof(MockTelegramPublisher)))
 			.Returns(primaryPublisher)
 			.Returns(secondaryPublisher);
 
@@ -315,7 +315,7 @@ public TelegramProvideServiceRecoveryTests()
 
 		var customTypes = new[] { typeof(MockTelegramPublisher) };
 
-		_mockServiceProvider.Setup(x => x.GetService(typeof(MockTelegramPublisher), null))
+		_mockServiceProvider.Setup(x => x.GetService(typeof(MockTelegramPublisher)))
 			.Returns(primaryPublisher);
 
 		_service.Subscribe(
@@ -367,7 +367,7 @@ public TelegramProvideServiceRecoveryTests()
 			typeof(MockTelegramPublisher)
 		};
 
-		_mockServiceProvider.SetupSequence(x => x.GetService(typeof(MockTelegramPublisher), null))
+		_mockServiceProvider.SetupSequence(x => x.GetService(typeof(MockTelegramPublisher)))
 			.Returns(primaryPublisher)
 			.Returns(secondaryPublisher);
 
@@ -425,7 +425,7 @@ public TelegramProvideServiceRecoveryTests()
 			typeof(MockTelegramPublisher)
 		};
 
-		_mockServiceProvider.SetupSequence(x => x.GetService(typeof(MockTelegramPublisher), null))
+		_mockServiceProvider.SetupSequence(x => x.GetService(typeof(MockTelegramPublisher)))
 			.Returns(highPriorityPublisher)
 			.Returns(lowPriorityPublisher);
 

--- a/tests/KyoshinEewViewer.Tests/Services/TelegramProvideServiceTests.cs
+++ b/tests/KyoshinEewViewer.Tests/Services/TelegramProvideServiceTests.cs
@@ -52,7 +52,7 @@ public class TelegramProvideServiceTests : IDisposable
 			typeof(MockTelegramPublisher)
 		};
 
-		_mockServiceProvider.SetupSequence(x => x.GetService(typeof(MockTelegramPublisher), null))
+		_mockServiceProvider.SetupSequence(x => x.GetService(typeof(MockTelegramPublisher)))
 			.Returns(mockPublisher1)
 			.Returns(mockPublisher2);
 
@@ -79,9 +79,9 @@ public class TelegramProvideServiceTests : IDisposable
 			SupportedCategories = [InformationCategory.Tsunami]
 		};
 
-		_mockServiceProvider.Setup(x => x.GetService(typeof(DmdataRedundantTelegramPublisher), null))
+		_mockServiceProvider.Setup(x => x.GetService(typeof(DmdataRedundantTelegramPublisher)))
 			.Returns(mockDmdata);
-		_mockServiceProvider.Setup(x => x.GetService(typeof(JmaXmlTelegramPublisher), null))
+		_mockServiceProvider.Setup(x => x.GetService(typeof(JmaXmlTelegramPublisher)))
 			.Returns(mockJma);
 
 		// Act
@@ -113,7 +113,7 @@ public class TelegramProvideServiceTests : IDisposable
 			typeof(MockTelegramPublisher)
 		};
 
-		_mockServiceProvider.SetupSequence(x => x.GetService(typeof(MockTelegramPublisher), null))
+		_mockServiceProvider.SetupSequence(x => x.GetService(typeof(MockTelegramPublisher)))
 			.Returns(failingPublisher)
 			.Returns(workingPublisher);
 
@@ -141,7 +141,7 @@ public class TelegramProvideServiceTests : IDisposable
 			typeof(MockTelegramPublisher)
 		};
 
-		_mockServiceProvider.SetupSequence(x => x.GetService(typeof(MockTelegramPublisher), null))
+		_mockServiceProvider.SetupSequence(x => x.GetService(typeof(MockTelegramPublisher)))
 			.Returns((object?)null) // 最初のPublisherは見つからない
 			.Returns(workingPublisher);
 
@@ -159,7 +159,7 @@ public class TelegramProvideServiceTests : IDisposable
 		var publisher = new MockTelegramPublisher();
 		var customTypes = new[] { typeof(MockTelegramPublisher) };
 
-		_mockServiceProvider.Setup(x => x.GetService(typeof(MockTelegramPublisher), null))
+		_mockServiceProvider.Setup(x => x.GetService(typeof(MockTelegramPublisher)))
 			.Returns(publisher);
 
 		// Act
@@ -178,7 +178,7 @@ public class TelegramProvideServiceTests : IDisposable
 		var publisher = new MockTelegramPublisher();
 		var customTypes = new[] { typeof(MockTelegramPublisher) };
 
-		_mockServiceProvider.Setup(x => x.GetService(typeof(MockTelegramPublisher), null))
+		_mockServiceProvider.Setup(x => x.GetService(typeof(MockTelegramPublisher)))
 			.Returns(publisher);
 
 		await _service.StartAsync(customTypes);
@@ -235,7 +235,7 @@ public class TelegramProvideServiceTests : IDisposable
 			typeof(MockTelegramPublisher)  // 低優先度
 		};
 
-		_mockServiceProvider.SetupSequence(x => x.GetService(typeof(MockTelegramPublisher), null))
+		_mockServiceProvider.SetupSequence(x => x.GetService(typeof(MockTelegramPublisher)))
 			.Returns(highPriorityPublisher)
 			.Returns(lowPriorityPublisher);
 

--- a/tests/KyoshinEewViewer.Tests/TestInitializer.cs
+++ b/tests/KyoshinEewViewer.Tests/TestInitializer.cs
@@ -1,0 +1,19 @@
+using ReactiveUI.Builder;
+using System.Runtime.CompilerServices;
+
+namespace KyoshinEewViewer.Tests;
+
+internal static class TestInitializer
+{
+	/// <summary>
+	/// ReactiveUI 12 以降は明示的な初期化が必須になっており、
+	/// アプリ側は Avalonia の UseReactiveUI() で初期化されるがテストホストでは実行されない。
+	/// WhenAnyValue 等を使用するコードが TypeInitializationException で失敗するため、
+	/// テストアセンブリの読み込み時に一度だけ初期化する。
+	/// </summary>
+	[ModuleInitializer]
+	internal static void Initialize()
+		=> RxAppBuilder.CreateReactiveUIBuilder()
+			.WithCoreServices()
+			.BuildApp();
+}


### PR DESCRIPTION
フォークを触っていた際にテストが落ちていることに気づいたため調査しました。テストはハングしたうえで47件失敗していましたが、原因はどちらもテストコードにありました

1つ目は、ReactiveUI 12から明示的な初期化が必要になったことです (#178)

アプリではAvaloniaの`UseReactiveUI()`で初期化されますが、テストではそこを経由しないため、`WhenAnyValue`の呼び出しが`TypeInitializationException`で失敗していました。このため、`[ModuleInitializer]`で一度だけ初期化するようにしています

2つ目は、Splatの`GetService`のオーバーロード変更です

アプリでは`GetService(type)`を呼び出しますが、テストでは`GetService(type, null)`をモックしていたため、現在のバージョンではモックが一致せず、Publisherが初期化されない状態になっていました。その結果、複数のテストが空のコレクションを検証して失敗し、`ConcurrentTelegramArrival_ShouldHandleAllMessages`も到着しない電文を待ち続けてハングしていました

修正後は238件すべて通ります

モックの修正が52箇所と多いので、このPRでは呼び出しを`GetService(type, null)`に揃えて差分を少し小さくすることもできます。そのほうがよければやります
