### PR TITLE
fix: NuGet のグループ更新を minor / patch に限定

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,4 @@ updates:
       nuget:
         patterns:
           - "*"
+        update-types: ["minor", "patch"]


### PR DESCRIPTION
ツイート見て、ちょっと調べてみた
今回の変更で NuGet のグループ更新を `minor` / `patch` だけにしている
これで major アップデートがグループ PR に入らなくなる
Dependabot 側の既知の問題(dependabot/dependabot-core#11398)で、`ignore` の major 制限がグループ更新に正しく適用されないケースがあるみたい
今回の変更で回避できるといいんだけど
#209 はこの変更入れたあとに閉じるのがよさそう
それとも #209 のコメントで `@dependabot recreate` すると、閉じずに今の設定で PR を作り直せるみたい