### PR TITLE
fix: NuGet のグループ更新で ReactiveUI.Avalonia / Splat を固定

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,8 +20,15 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+      # ReactiveUI.Avalonia 12.1.0 以降は ReactiveUI 24 / ReactiveUI.Primitives に移行しており、
+      # 本アプリの System.Reactive ベースのコードと互換性がない（ビルドが壊れる）。12.1.0 未満に固定する。
+      - dependency-name: "ReactiveUI.Avalonia"
+        versions: [">=12.1.0"]
+      # Splat 20.2.0 は ReactiveUI.Avalonia 12.1.1（ReactiveUI 24 / Primitives 移行版）が要求するバージョンで、
+      # 12.1.1 とセットでグループ更新に含まれる。連動して 20.0.0 未満に固定する。
+      - dependency-name: "Splat"
+        versions: [">=20.0.0"]
     groups:
       nuget:
         patterns:
           - "*"
-        update-types: ["minor", "patch"]

--- a/common.props
+++ b/common.props
@@ -63,7 +63,7 @@
 	</PropertyGroup>
 	
 	<PropertyGroup>
-        <AvaloniaVersion>12.1.0</AvaloniaVersion>
+        <AvaloniaVersion>12.1.1</AvaloniaVersion>
         <SplatVersion>19.4.1</SplatVersion>
         <DotnetVersion>10.0.10</DotnetVersion>
     </PropertyGroup>
@@ -83,7 +83,7 @@
 		<PackageReference Condition="$(RuntimeIdentifier.StartsWith('linux'))" Include="Mono.Posix.NETStandard" Version="1.0.0" />
 
         <PackageReference Condition="'$(UsingMicrosoftNETSdkWeb)' != 'true'" Include="Microsoft.Extensions.Logging" Version="$(DotnetVersion)" />
-		<PackageReference Include="NReco.Logging.File" Version="1.3.1" />
+		<PackageReference Include="NReco.Logging.File" Version="1.4.0" />
 
 		<PackageReference Include="KyoshinMonitorLib" Version="0.4.6" />
 		<PackageReference Include="KyoshinMonitorLib.SkiaImages" Version="0.4.6" />

--- a/src/KyoshinEewViewer/KyoshinEewViewer.csproj
+++ b/src/KyoshinEewViewer/KyoshinEewViewer.csproj
@@ -26,16 +26,16 @@
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(DotnetVersion)" />
         <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="$(DotnetVersion)" />
         <PackageReference Include="System.IO.Ports" Version="$(DotnetVersion)" />
-        <PackageReference Include="Sentry.Extensions.Logging" Version="6.7.0" />
+        <PackageReference Include="Sentry.Extensions.Logging" Version="6.8.0" />
         <PackageReference Include="Splat.Microsoft.Extensions.Logging" Version="$(SplatVersion)" />
 
         <PackageReference Include="Xaml.Behaviors.Avalonia" Version="12.0.5" />
-        <PackageReference Include="LiveMarkdown.Avalonia" Version="2.2.1" />
+        <PackageReference Include="LiveMarkdown.Avalonia" Version="2.3.0" />
         <PackageReference Include="Avalonia.AvaloniaEdit" Version="12.0.0" />
         <PackageReference Include="System.ServiceModel.Syndication" Version="$(DotnetVersion)" />
         <PackageReference Include="System.Text.Encoding.CodePages" Version="$(DotnetVersion)" />
         
-        <PackageReference Include="Scriban" Version="7.2.5" />
+        <PackageReference Include="Scriban" Version="7.2.6" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Sandboxes/SlackBot/SlackBot.csproj
+++ b/src/Sandboxes/SlackBot/SlackBot.csproj
@@ -17,7 +17,7 @@
 	<!-- パッケージ参照 -->
 	<ItemGroup>
 		<PackageReference Include="Avalonia.Headless" Version="$(AvaloniaVersion)" />
-		<PackageReference Include="SlackNet" Version="0.17.10" />
+		<PackageReference Include="SlackNet" Version="0.17.11" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
前回のPRは十分な確認をしないまま出してしまったから、まず謝っておく

今回は俺が先にフォーク上で実際にdependabotを動かして、更新内容を確認してから作業した

グループ化されたPRにSplatのメジャーバンプ（19.4.1 → 20.2.0）が含まれていて、update-types: [minor, patch] の設定と矛盾するように見えたので、フィルタ自体が壊れているのか、許可された更新の副作用として強制されたものなのか確認した

結論としてフィルタは正しく機能していて、Splatのバンプは許可されているReactiveUI.Avalonia 12.0.3 → 12.1.1（minor）が要求する推移的な依存の結果だった

<details>
<summary>検証ログ</summary>

nuspecの依存関係を比較

    curl -s https://api.nuget.org/v3-flatcontainer/reactiveui.avalonia/12.0.3/reactiveui.avalonia.nuspec | grep -A1 '"Splat"'
    curl -s https://api.nuget.org/v3-flatcontainer/reactiveui.avalonia/12.1.1/reactiveui.avalonia.nuspec | grep -A1 '"Splat"'

    12.0.3 -> <dependency id="Splat" version="[19.4.1, )" />
    12.1.1 -> <dependency id="Splat" version="[20.2.0, )" />

ReactiveUI.Avalonia 12.1.1 + Splat 19.4.1 を直接参照する最小プロジェクトでrestore

    <PackageReference Include="ReactiveUI.Avalonia" Version="12.1.1" />
    <PackageReference Include="Splat" Version="19.4.1" />

    dotnet restore proof-splat19.csproj

    error NU1605: Warning As Error: Detected package downgrade: Splat from 20.2.0 to 19.4.1.
    error NU1605:  proof-splat19 -> ReactiveUI.Avalonia 12.1.1 -> Splat (>= 20.2.0)
    error NU1605:  proof-splat19 -> Splat (>= 19.4.1)
      Failed to restore proof-splat19.csproj (in 1.36 sec).

restoreがNU1605で失敗するため、ReactiveUI.Avalonia 12.1.1を入れた状態ではSplat 19.4.1を維持できない

同じ構成でSplatだけ20.2.0（dependabotが選んだバージョン）にすると

    dotnet restore proof-splat20.csproj

    Restored proof-splat20.csproj (in 826 ms).

project.assets.jsonの解決結果

    ReactiveUI.Avalonia/12.1.1
    Splat/20.2.0

</details>

それとは別に、ReactiveUI.Avalonia 12.1.1は内部でReactiveUI 24.1.0とReactiveUI.Primitives 7.1.0も要求してきて、こちらはSystem.Reactiveベースの既存APIが削除されているため、そのまま上げると既存コードがビルドできなくなる
それ以外の変更は #211 と同等

どちらかのパッケージをこれ以上上げるにはReactiveUI 24 / Primitives 7への移行が必要になる
そのため、現状ではSplat 20.2.0を個別に許可するのではなく、ReactiveUI.Avalonia側の更新を止める形でdependabot.ymlに固定した

ただしこの固定はずっと安全というわけではなく、他のパッケージの更新が積み重なっていくにつれて将来的に問題が出てくる可能性が高い
なるべく早いうちに移行しておくことを勧める